### PR TITLE
Update logo bitmaps with correct gamma

### DIFF
--- a/README
+++ b/README
@@ -7,6 +7,7 @@ These were generated from the OE4T logo with the following imagemagick command:
 
     convert.im7 ${_input_file} \
         -type truecolor \
+        -colorspace RGB \
         -resize ${W}x${H}\> \
         -gravity center \
         -background ${SPLASH_GRAPHIC_BACKGROUND} \

--- a/logo-1080.bmp
+++ b/logo-1080.bmp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:181aa9b27ba2f7ee32905c980e7863c361036aee5743faf54e0531a1eb6b38e5
-size 6221626
+oid sha256:b6a86ceb0b80e7c0187601cc10fe4b189f3cf642be56e852c96b3e5426c2edf4
+size 6220922

--- a/logo-480.bmp
+++ b/logo-480.bmp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7debc456e3e4edc907dfad95419d9756a4c74b1415ee12ee347ac70304b6756b
-size 922426
+oid sha256:76c7a9dbdeacf601c9980a084c2778e6535a0cb94384dd247d3c2ee5d1f89cbf
+size 921722

--- a/logo-720.bmp
+++ b/logo-720.bmp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7001f3ea0f329f3a523d858cebf981332b06eafaab61c2b89c13e28250d9af4b
-size 2765626
+oid sha256:1433801a3c3796867606ade2a1eaa6d0520d3769fb43b4d032bc93d33ddb7196
+size 2764922


### PR DESCRIPTION
The nvdisp win settings in u-boot and cboot both expect linear RGB
input buffers. The imagemagick settings have been updated and the
bitmaps regenerated to output RGB (rather than sRGB) buffers, so
the correct gamma is used when displayed by the bootloader.